### PR TITLE
Restrict patch to NamedTuple

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ConstructionBase is a very lightwight package, that provides primitive functions for construction of objects:
 ```julia
-setproperties(obj::MyType, patch)
+setproperties(obj::MyType, patch::NamedTuple)
 constructorof(MyType)
 ```
 These functions can be overloaded and doing so provides interoperability the following packages:

--- a/src/ConstructionBase.jl
+++ b/src/ConstructionBase.jl
@@ -72,7 +72,7 @@ function assert_hasfields(T, fnames)
 end
 
 """
-    setproperties(obj, patch)
+    setproperties(obj, patch::NamedTuple)
 
 Return a copy of `obj` with attributes updates accoring to `patch`.
 
@@ -111,7 +111,7 @@ S("A", 2, "cc")
 # Overloading
 
 **WARNING** The signature `setproperties(obj::MyType; kw...)` should never be overloaded.
-Instead `setproperties(obj::MyType, patch)` should be overloaded.
+Instead `setproperties(obj::MyType, patch::NamedTuple)` should be overloaded.
 """
 function setproperties end
 
@@ -119,7 +119,7 @@ function setproperties(obj; kw...)
     setproperties(obj, (;kw...))
 end
 
-@generated function setproperties(obj, patch)
+@generated function setproperties(obj, patch::NamedTuple)
     assert_hasfields(obj, fieldnames(patch))
     args = map(fieldnames(obj)) do fn
         if fn in fieldnames(patch)
@@ -134,7 +134,7 @@ end
     )
 end
 
-@generated function setproperties(obj::NamedTuple, patch)
+@generated function setproperties(obj::NamedTuple, patch::NamedTuple)
     # this function is only generated to force the following check
     # at compile time
     assert_hasfields(obj, fieldnames(patch))


### PR DESCRIPTION
Current `setproperties` spec indicates that users need to support arbitrary `patch` object.  Doing this in general requires unnecessary reflection-based code (e.g., you don't need to use `fieldnames` for `NamedTuple`s as you can just dispatch on `::NamedTuple{names}`).  Instead, why not specify that it is only required to overload `setproperties(::MyType, ::NamedTuple)`?  We may also need to support other patch types in the future (e.g., `Dict`).  Restricting the patch type would help it.
