### PR TITLE
Define constructorof for Tuple and NamedTuple?

### DIFF
--- a/src/ConstructionBase.jl
+++ b/src/ConstructionBase.jl
@@ -72,6 +72,10 @@ T{Int64,Int64}(10, 2)
     getfield(parentmodule(T), nameof(T))
 end
 
+constructorof(::Type{<:Tuple}) = tuple
+constructorof(::Type{<:NamedTuple{names}}) where names =
+    NamedTuple{names} ∘ tuple
+
 function assert_hasfields(T, fnames)
     for fname in fnames
         if !(fname in fieldnames(T))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,6 +12,10 @@ end
     @inferred constructorof(AB{Int, Int})
     @test constructorof(AB{Int, Int})(1, 2) === AB(1,2)
     @test constructorof(AB{Int, Int})(1.0, 2) === AB(1.0,2)
+    @test constructorof(typeof((a=1, b=2)))(1.0, 2) === (a=1.0, b=2)
+    @test constructorof(NamedTuple{(:a, :b)})(1.0, 2) === (a=1.0, b=2)
+    @test constructorof(Tuple)(1.0, 2) === (1.0, 2)
+    @test constructorof(Tuple{Nothing, Missing})(1.0, 2) === (1.0, 2)
 end
 
 @testset "setproperties" begin


### PR DESCRIPTION
I started implementing this because I remember doing [something similer in Kaleido.jl](https://github.com/tkf/Kaleido.jl/blob/080406ffe05aa47770cf6294610196447b0c11fa/src/base.jl#L40-L42) but then realized that what I did in Kaleido.jl is a bit differnt from actual `constructorof` spec. So, this PR is not driven by a real need at this point.  However, since `Tuple` and `NamedTuple` are so basic that I think it makes sense to support this.  What do you think?

(One potential benefit was that we can remove `setproperties(::NamedTuple, ::NamedTuple)` with this PR. But the inference test failed with the generic fallback so that's no go.)
