### PR TITLE
Add a section "Tips for designing types"

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,2 +1,3 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+Setfield = "efcf1570-3423-57d1-acb7-fd33fddbac46"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -3,8 +3,120 @@
 ```@index
 ```
 
+## Interface
+
 ```@docs
 ConstructionBase
 ConstructionBase.constructorof
 ConstructionBase.setproperties
 ```
+
+## [Tips for designing types](@id type-tips)
+
+When designing types from scratch, it is recommended to structure the types in
+such a way that overloading `constructorof` or `setproperties` is unnecessary in
+the first place.  For simple `struct`s whose type parameters can be determined
+from field values, `ConstructionBase` works without any customization, provided
+that the "type-less" constructor exists.  However, it is often useful or
+required to have type parameters that cannot be determined from field values.
+One way to solve this problem is to define singleton types that would determine
+the type parameters:
+
+```jldoctest tips
+abstract type OutputBy end
+struct Mutating <: OutputBy end
+struct Returning <: OutputBy end
+
+struct Add{O <: OutputBy, T}
+    outputby::O
+    value::T
+end
+
+(f::Add{Mutating})(y, x) = y .= x .+ f.value
+(f::Add{Returning})(x) = x .+ f.value
+
+add1! = Add(Mutating(), 1)
+
+using ConstructionBase
+add2 = constructorof(typeof(add1!))(Returning(), 2)
+add2(1)
+
+# output
+
+3
+```
+
+`setproperties` works as well:
+
+```jldoctest tips
+add3 = setproperties(add2; value=3)
+add3(1)
+
+# output
+
+4
+```
+
+Note that no overloading of `ConstructionBase` functions was required.
+Importantly, this also provides an interface to change type parameters
+out-of-the-box:
+
+```jldoctest tips
+add3! = setproperties(add3; outputby=Mutating())
+add3!([0], 1)
+
+# output
+
+1-element Array{Int64,1}:
+ 4
+```
+
+Furthermore, it would work with packages depending on `ConstructionBase` such
+as [Setfield.jl](https://github.com/jw3126/Setfield.jl).
+
+```jldoctest tips
+using Setfield: @set
+add3′ = @set add3!.outputby = Returning()
+add3′ === add3
+
+# output
+
+true
+```
+
+!!! note
+
+    If it is desirable to keep fields as an implementation detail, combining
+    trait functions and
+    [`Setfield.FunctionLens`](https://jw3126.github.io/Setfield.jl/latest/#Setfield.FunctionLens)
+    may be useful:
+
+    ```jldoctest tips
+    OutputBy(x) = typeof(x)
+    OutputBy(::Type{<:Add{O}}) where O = O()
+
+    using Setfield: Setfield, @lens
+    Setfield.set(add::Add, ::typeof(@lens OutputBy(_)), o::OutputBy) =
+        @set add.outputby = o
+
+    obj = (add=add3!,)
+    obj′ = @set OutputBy(obj.add) = Returning()
+    obj′ === (add=add3,)
+
+    # output
+
+    true
+    ```
+
+    ```jldoctest tips
+    Setfield.set(::Type{Add{O0, T}}, ::typeof(@lens OutputBy(_)), ::O1) where {O0, T, O1 <: OutputBy} =
+        Add{O1, T}
+
+    T1 = typeof(add3!)
+    T2 = @set OutputBy(T1) = Returning()
+    T2 <: Add{Returning}
+
+    # output
+
+    true
+    ```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -13,14 +13,15 @@ ConstructionBase.setproperties
 
 ## [Tips for designing types](@id type-tips)
 
-When designing types from scratch, it is recommended to structure the types in
-such a way that overloading `constructorof` or `setproperties` is unnecessary in
-the first place.  For simple `struct`s whose type parameters can be determined
-from field values, `ConstructionBase` works without any customization, provided
-that the "type-less" constructor exists.  However, it is often useful or
-required to have type parameters that cannot be determined from field values.
-One way to solve this problem is to define singleton types that would determine
-the type parameters:
+When designing types from scratch, it is often possible to structure the types
+in such a way that overloading `constructorof` or `setproperties` is unnecessary
+in the first place.  It let types in your package work nicely with the ecosystem
+built on top of `ConstructionBase` even without explicitly depending on it.
+For simple `struct`s whose type parameters can be determined from field values,
+`ConstructionBase` works without any customization, provided that the "type-less"
+constructor exists.  However, it is often useful or required to have type
+parameters that cannot be determined from field values. One way to solve this
+problem is to define singleton types that would determine the type parameters:
 
 ```jldoctest tips
 abstract type OutputBy end

--- a/src/constructorof.md
+++ b/src/constructorof.md
@@ -60,3 +60,5 @@ T{Float64,Int64}(1.0, 2)
 julia> constructorof(typeof(t))(10, 2)
 T{Int64,Int64}(10, 2)
 ```
+
+See also [Tips section in the manual](@ref type-tips)


### PR DESCRIPTION
This probably is too opinionated to be in the official documentation, but I thought is worth a shot.  What do you think?

If you want to look at a semi-rendered version, see:
https://github.com/tkf/ConstructionBase.jl/blob/tips/docs/src/index.md#tips-for-designing-typesid-type-tips
