### PR TITLE
[RFC] add setproperties!!

### DIFF
--- a/src/ConstructionBase.jl
+++ b/src/ConstructionBase.jl
@@ -1,7 +1,8 @@
 module ConstructionBase
 
-export setproperties
+export setproperties, setproperties!, setproperties!!
 export constructorof
+
 
 # Use markdown files as docstring:
 for (name, path) in [
@@ -72,5 +73,26 @@ function setproperties_unknown_field_error(obj, patch)
     throw(ArgumentError(msg))
 end
 
+function setproperties!(obj, patch::NamedTuple)
+    _setproperties!(obj, pairs(patch)...)
+end
+
+_setproperties!(obj) = obj
+
+function _setproperties!(obj, (key, val), tail...)
+    Base.setproperty!(obj, key, val)
+    _setproperties!(obj, tail...)
+end
+
+ismutablestruct(x) = ismutablestruct(typeof(x))
+Base.@pure ismutablestruct(T::DataType) = T.mutable
+
+function setproperties!!(obj, patch::NamedTuple)
+    if ismutablestruct(obj)
+        setproperties!(obj, patch)
+    else
+        setproperties(obj, patch)
+    end
+end
 
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -47,3 +47,36 @@ end
     @inferred setproperties((a=1, b=2), a=1.0)
     @inferred setproperties((a=1, b=2), (a=1.0,))
 end
+
+mutable struct TwoMutableInts
+    a::Int
+    b::Int
+end
+
+struct TwoImmutableInts
+    a::Int
+    b::Int
+end
+
+@testset "setproperties!" begin
+    o = TwoMutableInts(1,2)
+    o2 = @inferred setproperties!(o, (a=10, b=20))
+    @test o2 isa TwoMutableInts
+    @test o2.a === 10
+    @test o2.b === 20
+
+    @test o.a === 10
+    @test o.b === 20
+end
+
+@testset "setproperties!!" begin
+    o = TwoImmutableInts(1,2)
+    o2 = @inferred setproperties!!(o, (a=10, b=20))
+    @test o2 === TwoImmutableInts(10, 20)
+
+    o = TwoMutableInts(1,2)
+    o2 = @inferred setproperties!!(o, (a=10, b=20))
+    @test o2 isa TwoMutableInts
+    @test o2.a === 10
+    @test o2.b === 20
+end


### PR DESCRIPTION
Over at `Setfield` we have a PR that wants to add lenses that work on mutables and immutables. 
This requires `setproperties!!`, which currently lives in `BangBang` (or more precisely `setproperty!!`).
This PR investigates adding `setproperties!!` here instead. See also [this comment](https://github.com/jw3126/Setfield.jl/pull/92#discussion_r333235100)