### PR TITLE
WIP add constructors for base array wrappers

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,9 @@ uuid = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
 authors = ["Takafumi Arakaki", "Rafael Schouten", "Jan Weidner"]
 version = "1.0.0"
 
+[deps]
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
 [compat]
 julia = "1"
 

--- a/src/ConstructionBase.jl
+++ b/src/ConstructionBase.jl
@@ -86,5 +86,6 @@ function setproperties_unknown_field_error(obj, patch)
     throw(ArgumentError(msg))
 end
 
+include("nonstandard.jl")
 
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -80,38 +80,63 @@ end
     @test CustomSetproperties(2) === setproperties(o, (a=2,))
 end
 
-@testset "Default object constructors" begin
+@testset "constructors for non-standadard Base and LinearAlgebra etc objects" begin
     A1 = zeros(5, 6)
     A2 = ones(Float32, 5, 6)
+
     @testset "SubArray" begin
         subarray = view(A1, 1:2, 3:4)
-        fields = map(fn -> getfield(subarray, fn), fieldnames(typeof(subarray)))
-        @test constructorof(typeof(subarray))(fields...) === subarray
+        @test constructorof(typeof(subarray))(getproperties(subarray)...) === subarray
         @test all(constructorof(typeof(subarray))(A2, (Base.OneTo(2), 3:4), 0, 0) .== Float32[1 1; 1 1])
+        @inferred constructorof(typeof(subarray))(getproperties(subarray)...)
+        @inferred constructorof(typeof(subarray))(A2, (Base.OneTo(2), 3:4), 0, 0)
     end
+
     @testset "ReinterpretArray" begin
         ra1 = reinterpret(Float16, A1)
         @test constructorof(typeof(ra1))(A1) === ra1
+        @test constructorof(typeof(ra1))(getproperties(ra1)...) === ra1
         ra2 = constructorof(typeof(ra1))(A2)
         @test size(ra2) == (10, 6)
         @test eltype(ra2) == Float16
+        @inferred constructorof(typeof(ra1))(getproperties(ra1)...)
+        @inferred constructorof(typeof(ra1))(A2)
     end
+
     @testset "PermutedDimsArray" begin
         pda1 = PermutedDimsArray(A1, (2, 1))
         @test constructorof(typeof(pda1))(A1) === pda1
-        pda2 = constructorof(typeof(pda1))(A2)
-        @test eltype(pda2) == Float32
+        @test constructorof(typeof(pda1))(getproperties(pda1)...) === pda1
+        @test eltype(constructorof(typeof(pda1))(A2)) == Float32
+        @inferred constructorof(typeof(pda1))(getproperties(pda1)...)
+        @inferred constructorof(typeof(pda1))(A2)
     end
+
     @testset "Tridiagonal" begin
         d = randn(12)
         dl = randn(11)
         du = randn(11)
         tda = Tridiagonal(dl, d, du)
+        @test isdefined(tda, :du2) == false
         @test constructorof(typeof(tda))(dl, d, du) === tda
+        @test constructorof(typeof(tda))(getproperties(tda)...) === tda
+        # lu factorization defines du2
+        tda_lu = lu!(tda).factors
+        @test isdefined(tda_lu, :du2) == true
+        @test constructorof(typeof(tda_lu))(getproperties(tda_lu)...) === tda_lu
+        @test constructorof(typeof(tda_lu))(getproperties(tda)...) !== tda_lu
+        @test constructorof(typeof(tda_lu))(getproperties(tda)...) === tda
+        @inferred constructorof(typeof(tda))(getproperties(tda)...)
+        @inferred constructorof(typeof(tda))(getproperties(tda_lu)...)
     end
+
     @testset "LinRange" begin
         lr1 = LinRange(1, 7, 10)
+        lr2 = LinRange(1.0f0, 7.0f0, 10)
         @test constructorof(typeof(lr1))(1, 7, 10, nothing) === lr1
+        @test constructorof(typeof(lr1))(getproperties(lr2)...) === lr2
+        @inferred constructorof(typeof(lr1))(getproperties(lr1)...)
+        @inferred constructorof(typeof(lr1))(getproperties(lr2)...)
     end
 
 end


### PR DESCRIPTION
Some `constructorof` methods for  Base and LinearAlgebra array wrappers, as discussed in #34.

Probably we shouldn't add a constructor for `Tridiagonal` because of the undef field - seems it would break Accessors.jl/Flatten.jl etc? 

I'm not sure what to do about it long-term, possibly a PR to base using `nothing` instead of `undef` for `du2`? How many other structs have undef fields?

Closes #34

There are probably a bunch of other base objects that need `constuctorof` methods. Feel free to list more for me to add to this PR.