### PR TITLE
add getproperties method

### DIFF
--- a/src/ConstructionBase.jl
+++ b/src/ConstructionBase.jl
@@ -1,5 +1,6 @@
 module ConstructionBase
 
+export getproperties
 export setproperties
 export constructorof
 
@@ -7,6 +8,7 @@ export constructorof
 for (name, path) in [
     :ConstructionBase => joinpath(dirname(@__DIR__), "README.md"),
     :constructorof => joinpath(@__DIR__, "constructorof.md"),
+    :getproperties => joinpath(@__DIR__, "getproperties.md"),
     :setproperties => joinpath(@__DIR__, "setproperties.md"),
 ]
     # Don't fail when somehow importing docstrings doesn't work (we
@@ -37,6 +39,15 @@ struct NamedTupleConstructor{names} end
         Base.@_inline_meta
         $(NamedTuple{names, Tuple{args...}})(args)
     end
+end
+
+@generated function getproperties(obj)
+    fnames = fieldnames(obj)
+    fvals = map(fnames) do fname
+        Expr(:call, :getproperty, :obj, QuoteNode(fname))
+    end
+    fvals = Expr(:tuple, fvals...)
+    :(NamedTuple{$fnames}($fvals))
 end
 
 function setproperties(obj; kw...)

--- a/src/constructorof.md
+++ b/src/constructorof.md
@@ -32,16 +32,17 @@ julia> constructorof(S)(1,2,4)
 ERROR: AssertionError: a + b == checksum
 ```
 Instead `constructor` can be any object that satisfies the following properties:
-* It must be possible to reconstruct an object from its fields:
+* It must be possible to reconstruct an object from the `NamedTuple` returned by
+`getproperties`:
 ```julia
 ctor = constructorof(typeof(obj))
-@assert obj == ctor(fieldvalues(obj)...)
-@assert typeof(obj) == typeof(ctor(fieldvalues(obj)...))
+@assert obj == ctor(getproperties(obj)...)
+@assert typeof(obj) == typeof(ctor(getproperties(obj)...))
 ```
 * The other direction should hold for as many values of `args` as possible:
 ```julia
 ctor = constructorof(T)
-fieldvalues(ctor(args...)) == args
+getproperties(ctor(args...)) == args
 ```
 For instance given a suitable parametric type it should be possible to change
 the type of its fields:

--- a/src/getproperties.md
+++ b/src/getproperties.md
@@ -1,0 +1,42 @@
+    getproperties(obj)
+
+Return the fields of `obj` as a `NamedTuple`.
+
+# Examples
+```jldoctest
+julia> using ConstructionBase
+
+julia> struct S
+           a
+           b
+           c
+       end
+
+julia> s = S(1,2,3)
+S(1, 2, 3)
+
+julia> getproperties(s)
+(a = 10, b = 2, c = 4)
+```
+
+# Implementation
+
+`getproperties` is defined by default for all objects. However for a custom type `MyType`, 
+`getproperties(obj::MyType)` may be defined when objects may have undefined fields, 
+when it has calculated fields that should not be accessed or set manually, or
+other conditions that do not meet the specification with the default implementation.
+
+## Specification
+
+`getproperties` guarantees a couple of invariants. When overloading it, the user is responsible for ensuring them:
+
+1. Relation to `propertynames` and `fieldnames`: `getproperties` relates to `propertynames` and `getproperty`, not to `fieldnames` and `getfield`.
+   This means that any series `p₁, p₂, ..., pₙ` of `propertynames(obj)` that is not undefined should be returned by `getproperties`.
+2. `getproperties` is defined in relation to `constructorof` so that:
+   ```julia
+   obj == constructorof(obj)(getproperties(obj)...)
+   ```
+2. `getproperties` is defined in relation to `setproperties` so that:
+   ```julia
+   obj == setproperties(obj, getproperties(obj))
+   ```

--- a/src/setproperties.md
+++ b/src/setproperties.md
@@ -65,7 +65,11 @@ may be defined.
 1. Purity: `setproperties` is supposed to have no side effects. In particular `setproperties(obj, patch::NamedTuple)` may not mutate `obj`.
 2. Relation to `propertynames` and `fieldnames`: `setproperties` relates to `propertynames` and `getproperty`, not to `fieldnames` and `getfield`.
    This means that any subset `p₁, p₂, ..., pₙ` of `propertynames(obj)` is a valid set of properties, with respect to which the lens laws below must hold.
-3. `setproperties` should satisfy the lens laws:
+3. `setproperties` is defined in relation to `getproperties` so that:
+   ```julia
+   obj == setproperties(obj, getproperties(obj))
+   ```
+4. `setproperties` should satisfy the lens laws:
 
 For any valid set of properties `p₁, p₂, ..., pₙ`, following equalities must hold:
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,6 +18,13 @@ end
     @test constructorof(Tuple{Nothing, Missing})(1.0, 2) === (1.0, 2)
 end
 
+@testset "getproperties" begin
+    o = AB(1, 2)
+    @test getproperties(o) === (a=1, b=2)
+    @inferred getproperties(o)
+    @test getproperties(Empty()) === NamedTuple()
+end
+
 @testset "setproperties" begin
     o = AB(1,2)
     @test setproperties(o, (a=2, b=3))   === AB(2,3)


### PR DESCRIPTION
Adds a `getproperties` method, primarily to handle construction of objects with undefined fields, but also more broadly useful for getting object fields as a `NamedTuple`. See #36.