### PR TITLE
Add constructorof for anonymous functions

### DIFF
--- a/src/ConstructionBase.jl
+++ b/src/ConstructionBase.jl
@@ -87,5 +87,6 @@ function setproperties_unknown_field_error(obj, patch)
 end
 
 include("nonstandard.jl")
+include("functions.jl")
 
 end # module

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -1,5 +1,5 @@
 
-# Anonymous functions have no `new` constructor. Here we generaate
+# Anonymous functions have no `new` constructor. Here we generate
 # one for them based on the types of args passed to FunctionConstructor
 
 struct FunctionConstructor{F} end
@@ -7,7 +7,7 @@ struct FunctionConstructor{F} end
 @generated function (::FunctionConstructor{F})(args...) where F
     T = getfield(parentmodule(F), nameof(F))
     # Fallback for user-defined function objects
-    length(args) == length(F.parameters) || return :($T(args...))
+    (length(args) == length(F.parameters) && F.parameters == F.types) || return :($T(args...))
     # Define `new` for rebuilt function type that matches args
     exp = Expr(:new, Expr(:curly, T, args...))
     for i in 1:length(args)

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -1,0 +1,17 @@
+
+# Anonymous functions have no `new` constructor. Here we generaate
+# one for them based on the types of args passed to FunctionConstructor
+
+struct FunctionConstructor{F} end
+
+@generated function (::FunctionConstructor{F})(args...) where F
+    exp = Expr(:new, Expr(:curly, F.name.wrapper, args...))
+    for i in 1:length(args)
+        push!(exp.args, :(args[$i]))
+    end
+    return exp
+end
+
+function ConstructionBase.constructorof(f::Type{F}) where F <: Function
+    FunctionConstructor{F}()
+end

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -5,7 +5,11 @@
 struct FunctionConstructor{F} end
 
 @generated function (::FunctionConstructor{F})(args...) where F
-    exp = Expr(:new, Expr(:curly, F.name.wrapper, args...))
+    T = getfield(parentmodule(F), nameof(F))
+    # Fallback for user-defined function objects
+    length(args) == length(F.parameters) || return :($T(args...))
+    # Define `new` for rebuilt function type that matches args
+    exp = Expr(:new, Expr(:curly, T, args...))
     for i in 1:length(args)
         push!(exp.args, :(args[$i]))
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -148,9 +148,11 @@ end
 
     mult11 = multiplyer(1, 1)
     @test mult11(1) === 1
-    mult23 = ConstructionBase.constructorof(typeof(mult11))(2.0, 3.0)
+    mult23 = @inferred ConstructionBase.constructorof(typeof(mult11))(2.0, 3.0)
+    @inferred mult23(1)
     @test mult23(1) === 6.0
-    multbc = ConstructionBase.constructorof(typeof(mult23))("b", "c")
+    multbc = @inferred ConstructionBase.constructorof(typeof(mult23))("b", "c")
+    @inferred multbc("a")
     @test multbc("a") == "abc" 
 end
 
@@ -173,15 +175,17 @@ end
 @testset "Custom function object constructors" begin
     add1 = Adder(1)
     @test add1(1) === 2
-    add2 = ConstructionBase.constructorof(typeof(add1))(2.0)
-    @test add2(1) === 3.0
+    add2 = @inferred ConstructionBase.constructorof(typeof(add1))(2.0)
+    @inferred add2(1)
+    @test add2(1) == 3.0
     add12 = Adder2(1, 2)
-    @test add12(3) ==  6
-    add22 = ConstructionBase.constructorof(typeof(add12))(2.0, 2)
-    @test add22(3) ==  7.0
+    @test @inferred add12(3) ==  6
+    add22 = @inferred ConstructionBase.constructorof(typeof(add12))(2.0, 2)
+    @test @inferred add22(3) ==  7.0
 
     addtuple123 = AddTuple((1, 2, 3))
     @test addtuple123(1) === 7
-    addtuple234 = ConstructionBase.constructorof(typeof(addtuple123))((2.0, 3.0, 4.0))
+    addtuple234 = @inferred ConstructionBase.constructorof(typeof(addtuple123))((2.0, 3.0, 4.0))
+    @inferred addtuple234(1)
     @test addtuple234(1) === 10.0
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -165,6 +165,11 @@ struct Adder2{V} <: Function
 end
 (o::Adder2)(x) = o.value + o.int + x 
 
+struct AddTuple{T} <: Function
+    tuple::Tuple{T,T,T}
+end
+(o::AddTuple)(x) = sum(o.tuple) + x
+
 @testset "Custom function object constructors" begin
     add1 = Adder(1)
     @test add1(1) === 2
@@ -174,4 +179,9 @@ end
     @test add12(3) ==  6
     add22 = ConstructionBase.constructorof(typeof(add12))(2.0, 2)
     @test add22(3) ==  7.0
+
+    addtuple123 = AddTuple((1, 2, 3))
+    @test addtuple123(1) === 7
+    addtuple234 = ConstructionBase.constructorof(typeof(addtuple123))((2.0, 3.0, 4.0))
+    @test addtuple234(1) === 10.0
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -153,3 +153,25 @@ end
     multbc = ConstructionBase.constructorof(typeof(mult23))("b", "c")
     @test multbc("a") == "abc" 
 end
+
+struct Adder{V} <: Function
+    value::V
+end
+(o::Adder)(x) = o.value + x
+
+struct Adder2{V} <: Function
+    value::V
+    int::Int
+end
+(o::Adder2)(x) = o.value + o.int + x 
+
+@testset "Custom function object constructors" begin
+    add1 = Adder(1)
+    @test add1(1) === 2
+    add2 = ConstructionBase.constructorof(typeof(add1))(2.0)
+    @test add2(1) === 3.0
+    add12 = Adder2(1, 2)
+    @test add12(3) ==  6
+    add22 = ConstructionBase.constructorof(typeof(add12))(2.0, 2)
+    @test add22(3) ==  7.0
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -141,3 +141,15 @@ end
 
 end
 
+@testset "Anonymous function constructors" begin
+    function multiplyer(a, b)
+        x -> x * a * b
+    end
+
+    mult11 = multiplyer(1, 1)
+    @test mult11(1) === 1
+    mult23 = ConstructionBase.constructorof(typeof(mult11))(2.0, 3.0)
+    @test mult23(1) === 6.0
+    multbc = ConstructionBase.constructorof(typeof(mult23))("b", "c")
+    @test multbc("a") == "abc" 
+end


### PR DESCRIPTION
This allows reconstructing anonymous functions with new field values of any type, despite not having a default constructor.

Closes #32