### PR TITLE
check gensym name to avoid new on user defined Function objects

### DIFF
--- a/src/constructorof.md
+++ b/src/constructorof.md
@@ -62,4 +62,9 @@ julia> constructorof(typeof(t))(10, 2)
 T{Int64, Int64}(10, 2)
 ```
 
+`constructorof` is generated for all anonymous `Function`s lacking constructors,
+identified as having `gensym` `#` in their names. A custom struct `<: Function`
+with a `gensym` name may need to define `constructorof` manually.
+
+
 See also [Tips section in the manual](@ref type-tips)

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -4,10 +4,10 @@
 
 struct FunctionConstructor{F} end
 
-@generated function (::FunctionConstructor{F})(args...) where F
+@generated function (fc::FunctionConstructor{F})(args...) where F
     T = getfield(parentmodule(F), nameof(F))
-    # Fallback for user-defined function objects
-    (length(args) == length(F.parameters) && F.parameters == F.types) || return :($T(args...))
+    # We assume all gensym names are anonymous functions
+    _isgensym(nameof(F)) || return :($T(args...))
     # Define `new` for rebuilt function type that matches args
     exp = Expr(:new, Expr(:curly, T, args...))
     for i in 1:length(args)
@@ -19,3 +19,5 @@ end
 function ConstructionBase.constructorof(f::Type{F}) where F <: Function
     FunctionConstructor{F}()
 end
+
+_isgensym(s::Symbol) = occursin("#", string(s))


### PR DESCRIPTION
Switch to checking that the name is gensym and there is no constructor defined, as the heuristic for identifying anonymous functions, so that we don't call `new` on custom function structs when there is another constructor that could be called.  