### PR TITLE
bugfix SubArray

### DIFF
--- a/src/nonstandard.jl
+++ b/src/nonstandard.jl
@@ -3,7 +3,7 @@ using LinearAlgebra
 ### SubArray
 # `offset1` and `stride1` fields are calculated from parent indices.
 # Setting them has no effect.
-subarray_constructor(parent, indices, args...) = view(parent, indices...)
+subarray_constructor(parent, indices, args...) = SubArray(parent, indices)
 
 constructorof(::Type{<:SubArray}) = subarray_constructor
 


### PR DESCRIPTION
Using `view` for constructing `SubArray` introduces bugs where `view` is customised for some types of `AbstractArray`. This is less likely to happen with the `SubArray` constructor.