### PR TITLE
Fixed simple typo.

### DIFF
--- a/src/setproperties.md
+++ b/src/setproperties.md
@@ -1,6 +1,6 @@
     setproperties(obj, patch::NamedTuple)
 
-Return a copy of `obj` with attributes updates accoring to `patch`.
+Return a copy of `obj` with attributes updates according to `patch`.
 
 # Examples
 ```jldoctest


### PR DESCRIPTION
Just corrects a typo in the docstring of setproperties.