### PR TITLE
Use static property names type

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,17 +10,20 @@ jobs:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         version:
           - '1.0'
+          - '1.1'
+          - '1.2'
           - '1.3'
+          - '1.4'
           - '1.5'
+          - '1.6'
+          - '1.7'
           - 'nightly'
         os:
           - ubuntu-latest
-          - macOS-latest
-          - windows-latest
         arch:
           - x64
     steps:

--- a/src/ConstructionBase.jl
+++ b/src/ConstructionBase.jl
@@ -37,10 +37,6 @@ struct PropertyIndices{inds} end
 
 const PropertyKeys{K} = Union{PropertyNames{K},PropertyIndices{K}}
 
-Base.eltype(@nospecialize p::PropertyKeys) = eltype(typeof(p))
-Base.eltype(@nospecialize T::Type{<:PropertyIndices}) = Int
-Base.eltype(@nospecialize T::Type{<:PropertyNames}) = Symbol
-
 PropertyNames(::Type{T}) where {T} = PropertyNames{fieldnames(T)}()
 PropertyNames(@nospecialize(T::Type{<:NamedTuple})) = PropertyNames{T.parameters[1]}()
 PropertyNames(@nospecialize(x)) = PropertyNames(typeof(x))
@@ -67,12 +63,8 @@ end
 function Base.getindex(@nospecialize(p1::PropertyNames), @nospecialize(p2::PropertyIndices))
     PropertyNames{_getfields(values(p1), values(p2), _vlength(p2))}()
 end
-
-Base.isdone(@nospecialize(p::PropertyKeys), i::Int) = length(p) < i
-Base.iterate(::PropertyKeys{()}) = nothing
-Base.iterate(@nospecialize(p::PropertyKeys)) = @inbounds(p[1]), 2
-@inline function Base.iterate(@nospecialize(p::PropertyKeys), state::Int)
-    if Base.isdone(p, state)
+@inline function Base.iterate(@nospecialize(p::PropertyKeys), state::Int=1)
+    if length(p) > state
         return nothing
     else
         return @inbounds(p[state]), state + 1
@@ -114,15 +106,15 @@ end
 ##### setproperties
 ################################################################################
 setproperties(obj; kw...) = setproperties(obj, (;kw...))
-setproperties(obj             , patch::Tuple      ) = setproperties_object(obj     , patch )
-setproperties(obj             , patch::NamedTuple ) = setproperties_object(obj     , patch )
-setproperties(obj::NamedTuple , patch::Tuple      ) = setproperties_namedtuple(obj , patch )
-setproperties(obj::NamedTuple , patch::NamedTuple ) = setproperties_namedtuple(obj , patch )
-setproperties(obj::Tuple      , patch::Tuple      ) = setproperties_tuple(obj      , patch )
-setproperties(obj::Tuple      , patch::NamedTuple ) = setproperties_tuple(obj      , patch )
-
-setproperties_namedtuple(obj, patch::Tuple{}) = obj
-@noinline function setproperties_namedtuple(obj, patch::Tuple)
+setproperties(obj, patch) = isempty(patch) ? obj : _setproperties(obj, patch)
+function _setproperties(@nospecialize(obj::Tuple), @nospecialize(patch::Tuple))
+    _generated_setproperties(obj, patch, PropertyIndices(obj), PropertyIndices(patch))
+end
+function _setproperties(obj, patch)
+    _generated_setproperties(obj, patch, PropertyNames(obj), PropertyNames(patch))
+end
+_setproperties(::NamedTuple{fields}, patch::NamedTuple{fields}) where {fields} = patch
+@noinline function _setproperties(@nospecialize(obj::NamedTuple), patch::Tuple)
     msg = """
     setproperties(obj::NamedTuple, patch::Tuple) only allowed for empty Tuple. Got:
     obj = $obj
@@ -130,33 +122,14 @@ setproperties_namedtuple(obj, patch::Tuple{}) = obj
     """
     throw(ArgumentError(msg))
 end
-function setproperties_namedtuple(@nospecialize(obj), @nospecialize( patch))
-    _generated_setproperties(obj, patch, PropertyNames(obj), PropertyNames(patch))
-end
-function validate_setproperties_result(
-    nt_new::NamedTuple{fields}, nt_old::NamedTuple{fields}, obj, patch) where {fields}
-    nothing
-end
-@noinline function validate_setproperties_result(nt_new, nt_old, obj, patch)
-    O = typeof(obj)
-    _setproperties_object(O, fieldnames(O), fieldnames(typeof(patch)))
-end
-@noinline function _setproperties_result_error(O::DataType, @nospecialize(objsyms), @nospecialize(patchsyms))
+@noinline function _setproperties(@nospecialize(obj), @nospecialize(patch::Tuple))
     msg = """
-    Failed to assign properties $(patchsyms) to object with fields $(objsyms).
-    You may want to overload
-    ConstructionBase.setproperties(obj::$O, patch::NamedTuple)
-    ConstructionBase.getproperties(obj::$O)
+    setproperties(obj, patch::Tuple) only allowed for empty Tuple. Got:
+    obj = $obj
+    patch = $patch
     """
-    throw(ArgumentError(msg))
 end
-
-function setproperties_namedtuple(::NamedTuple{fields}, patch::NamedTuple{fields}) where {fields}
-    patch
-end
-
-setproperties_tuple(obj::Tuple, patch::NamedTuple{()}) = obj
-@noinline function setproperties_tuple(obj::Tuple, patch::NamedTuple)
+@noinline function _setproperties(@nospecialize(obj::Tuple), @nospecialize(patch::NamedTuple))
     msg = """
     setproperties(obj::Tuple, patch::NamedTuple) only allowed for empty NamedTuple. Got:
     obj  ::Tuple      = $obj
@@ -164,57 +137,31 @@ setproperties_tuple(obj::Tuple, patch::NamedTuple{()}) = obj
     """
     throw(ArgumentError(msg))
 end
-setproperties_tuple(::NTuple{N,Any}, patch::NTuple{N,Any}) where {N} = patch
-append(x,y) = (x..., y...)
-@noinline function throw_setproperties_tuple_error(obj, patch)
-    msg = """
-    Cannot call `setproperties(obj::Tuple, patch::Tuple)` with `length(obj) < length(patch)`. Got:
-    obj = $obj
-    patch = $patch
-    """
-    throw(ArgumentError(msg))
-end
-function setproperties_tuple(obj::NTuple{N,Any}, patch::NTuple{K,Any}) where {N,K}
-    if K > N
-        throw_setproperties_tuple_error(obj, patch)
-    end
-    append(patch, after(obj, Val{K}()))
-end
-function after(xs::Tuple, ::Val{N}) where {N}
-    after(Base.tail(xs), Val{N-1}())
-end
-function after(x::Tuple, ::Val{0})
-    x
-end
-
-setproperties_object(obj, patch::Tuple{}) = obj
-@noinline function setproperties_object(obj, @nospecialize(patch::Tuple))
-    msg = """
-    setproperties(obj, patch::Tuple) only allowed for empty Tuple. Got:
-    obj = $obj
-    patch = $patch
-    """
-end
-setproperties_object(obj, patch::NamedTuple{()}) = obj
-@inline function setproperties_object(obj, patch)
-    _generated_setproperties(obj, patch, PropertyNames(obj), PropertyNames(patch))
-end
-@generated function _generated_setproperties(obj, patch, ::PropertyNames{objsyms}, ::PropertyNames{patchsyms}) where {objsyms,patchsyms}
+@generated function _generated_setproperties(obj, patch, ::PropertyKeys{objkeys}, ::PropertyKeys{patchkeys}) where {objkeys,patchkeys}
     out = Expr(:call, :(constructorof(typeof(obj))))
-    names = Symbol[objsyms...]
-    for ps in patchsyms
-        if !in(ps, objsyms)
+    names = [objkeys...]
+    for ps in patchkeys
+        if !in(ps, objkeys)
             push!(names, ps)
         end
     end
-    if all(in(objsyms), names)
+    if all(in(objkeys), names)
         for n in names
             qn = QuoteNode(n)
-            push!(out.args, in(n, patchsyms) ? Expr(:call, :getfield, :patch, qn) : Expr(:call, :getproperty, :obj, qn))
+            push!(out.args, in(n, patchkeys) ? Expr(:call, :getfield, :patch, qn) : Expr(:call, :getproperty, :obj, qn))
         end
         return out
     else
-        return :(_setproperties_result_error(typeof(obj), objsyms, patchsyms))
+        return quote
+            O = typeof(obj)
+            msg = """
+            Failed to assign properties $(patchkeys) to object with fields $(objkeys).
+            You may want to overload
+            ConstructionBase.setproperties(obj::$O, patch::NamedTuple)
+            ConstructionBase.getproperties(obj::$O)
+            """
+            throw(ArgumentError(msg))
+        end
     end
 end
 

--- a/src/ConstructionBase.jl
+++ b/src/ConstructionBase.jl
@@ -24,14 +24,6 @@ for (name, path) in [
     end
 end
 
-@static if isdefined(Base, Symbol("@assume_effects"))
-    using Base: @assume_effects
-else
-    macro assume_effects(_, ex)
-        Base.@pure ex
-    end
-end
-
 """
     PropertyNames(T::Type) -> PropertyNames{fieldnames(T)}()
 
@@ -80,13 +72,9 @@ Base.@propagate_inbounds Base.getindex(@nospecialize(p::PropertyKeys), @nospecia
     end
 end
 
-constructorof(::Type{T}) where {T} = _default_constructorof(T)
-@assume_effects :total function _default_constructorof(T::DataType)
-    getfield(parentmodule(T), getfield(getfield(T, :name), :name))
-end
-
-constructorof(@nospecialize(T::Type{<:Tuple})) = tuple
-constructorof(@nospecialize(T::Type{<:NamedTuple})) = NamedTupleConstructor{fieldnames(T)}()
+@generated constructorof(::Type{T}) where T = getfield(parentmodule(T), nameof(T))
+constructorof(::Type{<:Tuple}) = tuple
+constructorof(::Type{<:NamedTuple{names}}) where names = NamedTupleConstructor{names}()
 
 struct NamedTupleConstructor{names} end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -37,15 +37,17 @@ end
     x = (a = 1, b  = 2, c = 3, d = 4)
     @test @inferred(getproperties(x, abprops)) === (a = 1, b = 2)
 end
-@testset "Issue #55" begin
-    struct Issue55
-        x::Int
-        y::Union{Nothing, Int}
-    end 
-    function update(x)
-        setproperties(x, (; x = x.x + 1))
+@static if VERSION ≥ v"1.7"
+    @testset "Issue #55" begin
+        struct Issue55
+            x::Int
+            y::Union{Nothing, Int}
+        end 
+        function update(x)
+            setproperties(x, (; x = x.x + 1))
+        end
+        @inferred update(Issue55(1,2))
     end
-    @inferred update(Issue55(1,2))
 end
 @testset "getproperties" begin
     o = AB(1, 2)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,6 +19,23 @@ end
     @test constructorof(Tuple{Nothing, Missing})(1.0, 2) === (1.0, 2)
 end
 
+@testset "PropertyNames" begin
+    abprops = ConstructionBase.PropertyNames{(:a, :b)}()
+    @test @inferred(abprops[1]) === :a
+    p1, s = iterate(abprops)
+    @test p1 == :a
+    p2, s = iterate(abprops, s)
+    @test p2 == :b
+    @test iterate(abprops, s) === nothing
+    # using PropertyNames helps with inferrence here
+    x = AB{Union{Int,Float64},Int}(1, 2);
+    @test @inferred(ConstructionBase.PropertyNames(x)) === abprops
+    @test @inferred(setproperties(x, (a = 2, b = 3))) == AB(2, 3)
+
+    x = (a = 1, b  = 2, c = 3, d = 4)
+    @test @inferred(getproperties(x, abprops)) === (a = 1, b = 2)
+end
+
 @testset "getproperties" begin
     o = AB(1, 2)
     @test getproperties(o) === (a=1, b=2)
@@ -311,3 +328,4 @@ end
     @inferred getproperties(funny_numbers(S20))
     @inferred getproperties(funny_numbers(S40))
 end
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,10 +27,12 @@ end
     p2, s = iterate(abprops, s)
     @test p2 == :b
     @test iterate(abprops, s) === nothing
-    # using PropertyNames helps with inferrence here
-    x = AB{Union{Int,Float64},Int}(1, 2);
-    @test @inferred(ConstructionBase.PropertyNames(x)) === abprops
-    @test @inferred(setproperties(x, (a = 2, b = 3))) == AB(2, 3)
+    @static if VERSION ≥ v"1.7"
+        # using PropertyNames helps with inferrence here
+        x = AB{Union{Int,Float64},Int}(1, 2);
+        @test @inferred(ConstructionBase.PropertyNames(x)) === abprops
+        @test @inferred(setproperties(x, (a = 2, b = 3))) == AB(2, 3)
+    end
 
     x = (a = 1, b  = 2, c = 3, d = 4)
     @test @inferred(getproperties(x, abprops)) === (a = 1, b = 2)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -35,7 +35,16 @@ end
     x = (a = 1, b  = 2, c = 3, d = 4)
     @test @inferred(getproperties(x, abprops)) === (a = 1, b = 2)
 end
-
+@testset "Issue #55" begin
+    struct Issue55
+        x::Int
+        y::Union{Nothing, Int}
+    end 
+    function update(x)
+        setproperties(x, (; x = x.x + 1))
+    end
+    @inferred update(Issue55(1,2))
+end
 @testset "getproperties" begin
     o = AB(1, 2)
     @test getproperties(o) === (a=1, b=2)


### PR DESCRIPTION
I was trying to put something together for Accessors.jl and found that some changes here can really improve performance downstream. 

The strategy used here is to only depend on `PropertyNames{fieldnames(obj)}()` to explicitly inject compile time information.
Only using `PropertyNames{names}` to construct the body of generated methods is more reliable than generic `::Type{T}`.

Using the example from [this isssue](https://github.com/JuliaObjects/ConstructionBase.jl/issues/55) demonstrates some of the performance differences here.

Where `A` and `B` are immutable types and `B` has a field with a union, this is what I get on the current master branch.
```julia
julia> @btime update($(Ref(A(1, 2)))[]);
  1.471 ns (0 allocations: 0 bytes)

julia> @btime update($(Ref(B(1, 2)))[]);
  387.926 ns (6 allocations: 176 bytes)
```

Problems with the union field are mostly absent using this PR.
```julia
julia> @btime update($(Ref(A(1, 2)))[]);
  1.760 ns (0 allocations: 0 bytes)

julia> @btime update($(Ref(B(1, 2)))[]);
  8.819 ns (0 allocations: 0 bytes)
```

Explicitly defining `PropertyNames` helps gives a tiny boost to performance.
```julia
ConstructionBase.PropertyNames(::Type{A}) = ConstructionBase.PropertyNames{(:x, :y)}()
ConstructionBase.PropertyNames(::Type{B}) = ConstructionBase.PropertyNames{(:x, :y)}()

julia> @btime update($(Ref(A(1, 2)))[]);
  1.471 ns (0 allocations: 0 bytes)

julia> @btime update($(Ref(B(1, 2)))[]);
  8.034 ns (0 allocations: 0 bytes)
``.`

This approach also allows manually unrolling operations so bigger collections get big performance boosts.
```julia
x = ntuple(identity, 40);
y = ntuple(identity, 30);

# master
@btime setproperties($x, $y); # 10.250 μs (10 allocations: 3.00 KiB)

# this PR
@btime setproperties($x, $y); # 3.984 ns (0 allocations: 0 bytes)
```

It might be worth noting that another internal change to `setproperties` was removing use of `getproperties`.
`PropertyNames` provides the information we really need from `getproperties` for reconstruction, which in turn helps us avoid needless `getproperty` calls.

I haven't changed any tests or documented anything here yet because I thought there might be some input on how well this really fits this package or if significant amount needs to be changed.