### PR TITLE
add downstream CI

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -16,6 +16,7 @@ jobs:
           - {repo: JuliaObjects/Accessors.jl}
           - {repo: JuliaFolds/BangBang.jl}
           - {repo: jw3126/Setfield.jl}
+          - {repo: rafaqz/Flatten.jl}
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -1,0 +1,51 @@
+name: IntegrationTest
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    name: ${{ matrix.package.repo }}/${{ matrix.julia-version }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        julia-version: [1.6, 1, nightly]
+        os: [ubuntu-latest]
+        package:
+          - {repo: JuliaObjects/Accessors.jl}
+          - {repo: JuliaFolds/BangBang.jl}
+          - {repo: jw3126/Setfield.jl}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.julia-version }}
+          arch: x64
+      - uses: julia-actions/julia-buildpkg@latest
+      - name: Clone Downstream
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ matrix.package.repo }}
+          path: downstream
+      - name: Load this and run the downstream tests
+        shell: julia --color=yes --project=downstream {0}
+        run: |
+          using Pkg
+          try
+            # force it to use this PR's version of the package
+            Pkg.develop(PackageSpec(path="."))  # resolver may fail with main deps
+            Pkg.update()
+            Pkg.test(coverage=true)  # resolver may fail with test time deps
+          catch err
+            err isa Pkg.Resolve.ResolverError || rethrow()
+            # If we can't resolve that means this is incompatible by SemVer and this is fine
+            # It means we marked this as a breaking change, so we don't need to worry about
+            # Mistakenly introducing a breaking change, as we have intentionally made one
+            @info "Not compatible with this release. No problem." exception=err
+            exit(0)  # Exit immediately, as a success
+          end
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v1
+        with:
+          file: lcov.info


### PR DESCRIPTION
Run tests of the most popular (thousands of users, hundreds of dependents) dependent packages that heavily rely on ConstructionBase.
Julia 1.6 (LTS), 1 latest, and nightly.
yml file originally taken from https://github.com/SciML/SciMLBase.jl/blob/master/.github/workflows/Downstream.yml.