### PR TITLE
support numeric propertynames

### DIFF
--- a/src/ConstructionBase.jl
+++ b/src/ConstructionBase.jl
@@ -71,10 +71,20 @@ end
     end
 end
 
+# names are consecutive integers: return tuple
+# names are symbols: return namedtuple
+# names are empty (object has no properties): also return namedtuple, for backwards compat and generally makes more sense
+@inline tuple_or_ntuple(names::Tuple{}, vals::Tuple) = NamedTuple{names}(vals)
+@inline tuple_or_ntuple(names::Tuple{Vararg{Symbol}}, vals::Tuple) = NamedTuple{names}(vals)
+@inline function tuple_or_ntuple(names::Tuple{Vararg{Int}}, vals::Tuple)
+    @assert names === ntuple(identity, length(names))
+    vals
+end
+
 if VERSION >= v"1.7"
     function getproperties(obj)
         fnames = propertynames(obj)
-        NamedTuple{fnames}(getproperty.(Ref(obj), fnames))
+        tuple_or_ntuple(fnames, getproperty.(Ref(obj), fnames))
     end
     function getfields(obj::T) where {T}
         fnames = fieldnames(T)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -298,6 +298,7 @@ Base.getproperty(obj::FieldProps, name::Symbol) = getproperty(getfield(obj, :com
     end
 end
 
+
 struct SProp
     names
 end
@@ -306,11 +307,15 @@ Base.getproperty(s::SProp, prop::Symbol) = "ps$prop"
 Base.getproperty(s::SProp, prop::Int) = "pi$prop"
 Base.getproperty(s::SProp, prop::String) = "pstr$prop"
 
-@testset "properties can be numbered" begin
-    @test getproperties(SProp((:a, :b))) === (a="psa", b="psb")
-    @test getproperties(SProp((1, 2))) === ("pi1", "pi2")
-    # what should it return?
-    @test_broken getproperties(SProp(("a", "b")))
+if VERSION >= v"1.7"
+    # automatic getproperties() supported only on 1.7+
+
+    @testset "properties can be numbered" begin
+        @test getproperties(SProp((:a, :b))) === (a="psa", b="psb")
+        @test getproperties(SProp((1, 2))) === ("pi1", "pi2")
+        # what should it return?
+        @test_broken getproperties(SProp(("a", "b")))
+    end
 end
 
 function funny_numbers(::Type{Tuple}, n)::Tuple

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -298,6 +298,21 @@ Base.getproperty(obj::FieldProps, name::Symbol) = getproperty(getfield(obj, :com
     end
 end
 
+struct SProp
+    names
+end
+Base.propertynames(s::SProp) = getfield(s, :names)
+Base.getproperty(s::SProp, prop::Symbol) = "ps$prop"
+Base.getproperty(s::SProp, prop::Int) = "pi$prop"
+Base.getproperty(s::SProp, prop::String) = "pstr$prop"
+
+@testset "properties can be numbered" begin
+    @test getproperties(SProp((:a, :b))) === (a="psa", b="psb")
+    @test getproperties(SProp((1, 2))) === ("pi1", "pi2")
+    # what should it return?
+    @test_broken getproperties(SProp(("a", "b")))
+end
+
 function funny_numbers(::Type{Tuple}, n)::Tuple
     types = [
         Int128, Int16, Int32, Int64, Int8,


### PR DESCRIPTION
A common case in the wild: `StructArray{Tuple{...}}`. Now, `getproperties` automatically supports this case and returns a tuple. The `setproperties` fallback isn't changed: by necessity, such objects define custom `propertynames`, so they require custom `setproperties` anyway.