### PR TITLE
Add package name as prefix to extensions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,8 +11,8 @@ IntervalSets = "8197267c-284f-5f27-9208-e0e47529a953"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [extensions]
-IntervalSetsExt = "IntervalSets"
-StaticArraysExt = "StaticArrays"
+ConstructionBaseIntervalSetsExt = "IntervalSets"
+ConstructionBaseStaticArraysExt = "StaticArrays"
 
 [compat]
 IntervalSets = "0.5, 0.6, 0.7"

--- a/ext/IntervalSetsExt.jl
+++ b/ext/IntervalSetsExt.jl
@@ -1,4 +1,4 @@
-module IntervalSetsExt
+module ConstructionBaseIntervalSetsExt
 
 using ConstructionBase
 using IntervalSets

--- a/ext/StaticArraysExt.jl
+++ b/ext/StaticArraysExt.jl
@@ -1,4 +1,4 @@
-module StaticArraysExt
+module ConstructionBaseStaticArraysExt
 
 using ConstructionBase
 using StaticArrays


### PR DESCRIPTION
Currently extensions with non-unique names cause collision and break precompilation with e.g. PackageCompiler.
The workaround, that many packages use is to add the package name as prefix to the extensions.
For longer discussion and information see [JuliaObjects/Accessors.jl#90](https://github.com/JuliaObjects/Accessors.jl/pull/90) or [JuliaStats/LogExpFunctions.jl#64](https://github.com/JuliaStats/LogExpFunctions.jl/pull/64).
This PR adds the package name as prefix.