### PR TITLE
Prefix parent package name to extension names

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,8 +11,8 @@ IntervalSets = "8197267c-284f-5f27-9208-e0e47529a953"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [extensions]
-IntervalSetsExt = "IntervalSets"
-StaticArraysExt = "StaticArrays"
+ConstructionBaseIntervalSetsExt = "IntervalSets"
+ConstructionBaseStaticArraysExt = "StaticArrays"
 
 [compat]
 IntervalSets = "0.5, 0.6, 0.7"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ConstructionBase"
 uuid = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
 authors = ["Takafumi Arakaki", "Rafael Schouten", "Jan Weidner"]
-version = "1.5.1"
+version = "1.5.2"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/ext/ConstructionBaseIntervalSetsExt.jl
+++ b/ext/ConstructionBaseIntervalSetsExt.jl
@@ -1,4 +1,4 @@
-module IntervalSetsExt
+module ConstructionBaseIntervalSetsExt
 
 using ConstructionBase
 using IntervalSets

--- a/ext/ConstructionBaseStaticArraysExt.jl
+++ b/ext/ConstructionBaseStaticArraysExt.jl
@@ -1,4 +1,4 @@
-module StaticArraysExt
+module ConstructionBaseStaticArraysExt
 
 using ConstructionBase
 using StaticArrays


### PR DESCRIPTION
- This prevents clash of extension names.
- Currently, clashes with Accessors.jl.
- And clashing names throw fatal errors while building sysimages.
- See: https://github.com/JuliaObjects/Accessors.jl/pull/104

