### PR TITLE
support non-tuple propertynames

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ConstructionBase"
 uuid = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
 authors = ["Takafumi Arakaki", "Rafael Schouten", "Jan Weidner"]
-version = "1.5.2"
+version = "1.5.3"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -319,6 +319,15 @@ if VERSION >= v"1.7"
         @test getproperties(SProp((1, 2))) === ("pi1", "pi2")
         # what should it return?
         @test_broken getproperties(SProp(("a", "b")))
+
+        @test_throws ErrorException getproperties(SProp((1, :a)))
+    end
+
+    @testset "propertynames can be a vector" begin
+        @test getproperties(SProp([:a, :b])) === (a="psa", b="psb")
+        @test getproperties(SProp(Symbol[])) === (;)
+        @test getproperties(SProp([1, 2])) === ("pi1", "pi2")
+        @test getproperties(SProp(Int[])) === ()
     end
 end
 


### PR DESCRIPTION
Fix a MethodError for types with `propertynames()::Vector` which is perfectly valid in Julia.
Also improve error message for unsupported `propertynames()` eltypes - for example, strings aren't supported for now because it's not clear what the output container should be.