### PR TITLE
Implementation of `setproperties` for `LinearAlgebra.Cholesky`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ConstructionBase"
 uuid = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
 authors = ["Takafumi Arakaki", "Rafael Schouten", "Jan Weidner"]
-version = "1.5.3"
+version = "1.5.4"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/nonstandard.jl
+++ b/src/nonstandard.jl
@@ -60,10 +60,10 @@ constructorof(::Type{<:Expr}) = (head, args) -> Expr(head, args...)::Expr
 ### Cholesky
 setproperties(C::LinearAlgebra.Cholesky, patch::NamedTuple{()}) = C
 function setproperties(C::LinearAlgebra.Cholesky, patch::NamedTuple{(:L,),Tuple{L}}) where {L<:LinearAlgebra.LowerTriangular}
-    return LinearAlgebra.Cholesky(parent(C.uplo === 'U' ? permutedims(patch.L) : patch.L), C.uplo, C.info)
+    return LinearAlgebra.Cholesky(C.uplo === 'U' ? copy(transpose(patch.L.data)) : patch.L.data, C.uplo, C.info)
 end
 function setproperties(C::LinearAlgebra.Cholesky, patch::NamedTuple{(:U,),Tuple{U}}) where {U<:LinearAlgebra.UpperTriangular}
-    return LinearAlgebra.Cholesky(parent(C.uplo === 'L' ? permutedims(patch.U) : patch.U), C.uplo, C.info)
+    return LinearAlgebra.Cholesky(C.uplo === 'L' ? copy(transpose(patch.U.data)) : patch.U.data, C.uplo, C.info)
 end
 function setproperties(
     C::LinearAlgebra.Cholesky,

--- a/src/nonstandard.jl
+++ b/src/nonstandard.jl
@@ -69,9 +69,5 @@ function setproperties(C::LinearAlgebra.Cholesky, patch::NamedTuple{(:UL,)})
     return LinearAlgebra.Cholesky(patch.UL, C.uplo, C.info)
 end
 function setproperties(C::LinearAlgebra.Cholesky, patch::NamedTuple)
-    if haskey(patch, :L) || haskey(patch, :U) || haskey(patch, :UL)
-        throw(ArgumentError("Can only patch one of :L, :U, :UL at the time"))
-    end
-
     throw(ArgumentError("Invalid patch for `Cholesky`: $(patch)"))
 end

--- a/src/nonstandard.jl
+++ b/src/nonstandard.jl
@@ -69,7 +69,7 @@ function setproperties(
     C::LinearAlgebra.Cholesky,
     patch::NamedTuple{(:UL,),Tuple{UL}}
 ) where {UL<:Union{LinearAlgebra.LowerTriangular,LinearAlgebra.UpperTriangular}}
-    return LinearAlgebra.Cholesky(parent(patch.UL), C.uplo, C.info)
+    return LinearAlgebra.Cholesky(patch.UL.data, C.uplo, C.info)
 end
 function setproperties(C::LinearAlgebra.Cholesky, patch::NamedTuple)
     throw(ArgumentError("Invalid patch for `Cholesky`: $(patch)"))

--- a/src/nonstandard.jl
+++ b/src/nonstandard.jl
@@ -68,6 +68,10 @@ end
 function setproperties(C::LinearAlgebra.Cholesky, patch::NamedTuple{(:UL,)})
     return LinearAlgebra.Cholesky(patch.UL, C.uplo, C.info)
 end
-@nospecialize function setproperties(C::LinearAlgebra.Cholesky, patch::NamedTuple)
-    error("Can only patch one of :L, :U, :UL at the time")
+function setproperties(C::LinearAlgebra.Cholesky, patch::NamedTuple)
+    if haskey(patch, :L) || haskey(patch, :U) || haskey(patch, :UL)
+        throw(ArgumentError("Can only patch one of :L, :U, :UL at the time"))
+    end
+
+    throw(ArgumentError("Invalid patch for `Cholesky`: $(patch)"))
 end

--- a/src/nonstandard.jl
+++ b/src/nonstandard.jl
@@ -59,13 +59,16 @@ constructorof(::Type{<:Expr}) = (head, args) -> Expr(head, args...)::Expr
 
 ### Cholesky
 setproperties(C::LinearAlgebra.Cholesky, patch::NamedTuple{()}) = C
-function setproperties(C::LinearAlgebra.Cholesky, patch::NamedTuple{(:L,)})
+function setproperties(C::LinearAlgebra.Cholesky, patch::NamedTuple{(:L,),Tuple{L}}) where {L<:LinearAlgebra.LowerTriangular}
     return LinearAlgebra.Cholesky(parent(C.uplo === 'U' ? permutedims(patch.L) : patch.L), C.uplo, C.info)
 end
-function setproperties(C::LinearAlgebra.Cholesky, patch::NamedTuple{(:U,)})
+function setproperties(C::LinearAlgebra.Cholesky, patch::NamedTuple{(:U,),Tuple{U}}) where {U<:LinearAlgebra.UpperTriangular}
     return LinearAlgebra.Cholesky(parent(C.uplo === 'L' ? permutedims(patch.U) : patch.U), C.uplo, C.info)
 end
-function setproperties(C::LinearAlgebra.Cholesky, patch::NamedTuple{(:UL,)})
+function setproperties(
+    C::LinearAlgebra.Cholesky,
+    patch::NamedTuple{(:UL,),Tuple{UL}}
+) where {UL<:Union{LinearAlgebra.LowerTriangular,LinearAlgebra.UpperTriangular}}
     return LinearAlgebra.Cholesky(parent(patch.UL), C.uplo, C.info)
 end
 function setproperties(C::LinearAlgebra.Cholesky, patch::NamedTuple)

--- a/src/nonstandard.jl
+++ b/src/nonstandard.jl
@@ -59,15 +59,15 @@ constructorof(::Type{<:Expr}) = (head, args) -> Expr(head, args...)::Expr
 
 ### Cholesky
 setproperties(C::LinearAlgebra.Cholesky, patch::NamedTuple{()}) = C
-function setproperties(C::LinearAlgebra.Cholesky, patch::NamedTuple{(:L,),Tuple{<:LinearAlgebra.LowerTriangular}})
+function setproperties(C::LinearAlgebra.Cholesky, patch::NamedTuple{(:L,),<:Tuple{<:LinearAlgebra.LowerTriangular}})
     return LinearAlgebra.Cholesky(C.uplo === 'U' ? copy(patch.L.data') : patch.L.data, C.uplo, C.info)
 end
-function setproperties(C::LinearAlgebra.Cholesky, patch::NamedTuple{(:U,),Tuple{<:LinearAlgebra.UpperTriangular}})
+function setproperties(C::LinearAlgebra.Cholesky, patch::NamedTuple{(:U,),<:Tuple{<:LinearAlgebra.UpperTriangular}})
     return LinearAlgebra.Cholesky(C.uplo === 'L' ? copy(patch.U.data') : patch.U.data, C.uplo, C.info)
 end
 function setproperties(
     C::LinearAlgebra.Cholesky,
-    patch::NamedTuple{(:UL,),Tuple{<:Union{LinearAlgebra.LowerTriangular,LinearAlgebra.UpperTriangular}}}
+    patch::NamedTuple{(:UL,),<:Tuple{<:Union{LinearAlgebra.LowerTriangular,LinearAlgebra.UpperTriangular}}}
 )
     return LinearAlgebra.Cholesky(patch.UL.data, C.uplo, C.info)
 end

--- a/src/nonstandard.jl
+++ b/src/nonstandard.jl
@@ -60,13 +60,13 @@ constructorof(::Type{<:Expr}) = (head, args) -> Expr(head, args...)::Expr
 ### Cholesky
 setproperties(C::LinearAlgebra.Cholesky, patch::NamedTuple{()}) = C
 function setproperties(C::LinearAlgebra.Cholesky, patch::NamedTuple{(:L,)})
-    return LinearAlgebra.Cholesky(C.uplo === 'U' ? permutedims(patch.L) : patch.L, C.uplo, C.info)
+    return LinearAlgebra.Cholesky(parent(C.uplo === 'U' ? permutedims(patch.L) : patch.L), C.uplo, C.info)
 end
 function setproperties(C::LinearAlgebra.Cholesky, patch::NamedTuple{(:U,)})
-    return LinearAlgebra.Cholesky(C.uplo === 'L' ? permutedims(patch.U) : patch.U, C.uplo, C.info)
+    return LinearAlgebra.Cholesky(parent(C.uplo === 'L' ? permutedims(patch.U) : patch.U), C.uplo, C.info)
 end
 function setproperties(C::LinearAlgebra.Cholesky, patch::NamedTuple{(:UL,)})
-    return LinearAlgebra.Cholesky(patch.UL, C.uplo, C.info)
+    return LinearAlgebra.Cholesky(parent(patch.UL), C.uplo, C.info)
 end
 function setproperties(C::LinearAlgebra.Cholesky, patch::NamedTuple)
     throw(ArgumentError("Invalid patch for `Cholesky`: $(patch)"))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -203,24 +203,28 @@ end
             @testset "only setting value" begin
                 # Empty patch.
                 C_new = ConstructionBase.setproperties(C, NamedTuple())
+                @test typeof(C_new) === typeof(C)
                 for f in propertynames(C)
                     @test getproperty(C_new, f) == getproperty(C, f)
                 end
 
                 # Update `L`.
                 C_new = ConstructionBase.setproperties(C, (L=2 .* parent(C.L),))
+                @test typeof(C_new) === typeof(C)
                 for f in propertynames(C)
                     @test getproperty(C_new, f) == 2 .* getproperty(C, f)
                 end
 
                 # Update `U`.
                 C_new = ConstructionBase.setproperties(C, (U=2 .* parent(C.U),))
+                @test typeof(C_new) === typeof(C)
                 for f in propertynames(C)
                     @test getproperty(C_new, f) == 2 .* getproperty(C, f)
                 end
 
                 # Update `UL`
                 C_new = ConstructionBase.setproperties(C, (UL=2 .* parent(C.UL),))
+                @test typeof(C_new) === typeof(C)
                 for f in propertynames(C)
                     @test getproperty(C_new, f) == 2 .* getproperty(C, f)
                 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -195,7 +195,9 @@ end
     end
 
     @testset "Cholesky" begin
-        X = Matrix(Diagonal(ones(3)))
+        # X = Matrix(Diagonal(ones(3)))
+        x = randn(3, 3)
+        X = x * x'
         @testset "uplo=$uplo" for uplo in ['L', 'U']
             C = Cholesky(X, uplo, 0)
 
@@ -207,37 +209,21 @@ end
                 end
 
                 # Update `L`.
-                C_new = ConstructionBase.setproperties(C, (L=parent(C.L),))
+                C_new = ConstructionBase.setproperties(C, (L=2 .* parent(C.L),))
                 for f in propertynames(C)
-                    @test getproperty(C_new, f) == getproperty(C, f)
+                    @test getproperty(C_new, f) == 2 .* getproperty(C, f)
                 end
 
                 # Update `U`.
-                C_new = ConstructionBase.setproperties(C, (U=parent(C.U),))
+                C_new = ConstructionBase.setproperties(C, (U=2 .* parent(C.U),))
                 for f in propertynames(C)
-                    @test getproperty(C_new, f) == getproperty(C, f)
+                    @test getproperty(C_new, f) == 2 .* getproperty(C, f)
                 end
 
                 # Update `UL`
-                C_new = ConstructionBase.setproperties(C, (UL=parent(C.UL),))
+                C_new = ConstructionBase.setproperties(C, (UL=2 .* parent(C.UL),))
                 for f in propertynames(C)
-                    @test getproperty(C_new, f) == getproperty(C, f)
-                end            # Update `L`.
-                C_new = ConstructionBase.setproperties(C, (L=parent(C.L),))
-                for f in propertynames(C)
-                    @test getproperty(C_new, f) == getproperty(C, f)
-                end
-
-                # Update `U`.
-                C_new = ConstructionBase.setproperties(C, (U=parent(C.U),))
-                for f in propertynames(C)
-                    @test getproperty(C_new, f) == getproperty(C, f)
-                end
-
-                # Update `UL`
-                C_new = ConstructionBase.setproperties(C, (UL=parent(C.UL),))
-                for f in propertynames(C)
-                    @test getproperty(C_new, f) == getproperty(C, f)
+                    @test getproperty(C_new, f) == 2 .* getproperty(C, f)
                 end
 
                 # Invalid patches.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -194,6 +194,60 @@ end
         @inferred constructorof(typeof(lr1))(getfields(lr2)...)
     end
 
+    @testset "Cholesky" begin
+        X = Matrix(Diagonal(ones(3)))
+        @testset "uplo=$uplo" for uplo in ['L', 'U']
+            C = Cholesky(X, uplo, 0)
+
+            @testset "only setting value" begin
+                # Empty patch.
+                C_new = ConstructionBase.setproperties(C, NamedTuple())
+                for f in propertynames(C)
+                    @test getproperty(C_new, f) == getproperty(C, f)
+                end
+
+                # Update `L`.
+                C_new = ConstructionBase.setproperties(C, (L=parent(C.L),))
+                for f in propertynames(C)
+                    @test getproperty(C_new, f) == getproperty(C, f)
+                end
+
+                # Update `U`.
+                C_new = ConstructionBase.setproperties(C, (U=parent(C.U),))
+                for f in propertynames(C)
+                    @test getproperty(C_new, f) == getproperty(C, f)
+                end
+
+                # Update `UL`
+                C_new = ConstructionBase.setproperties(C, (UL=parent(C.UL),))
+                for f in propertynames(C)
+                    @test getproperty(C_new, f) == getproperty(C, f)
+                end            # Update `L`.
+                C_new = ConstructionBase.setproperties(C, (L=parent(C.L),))
+                for f in propertynames(C)
+                    @test getproperty(C_new, f) == getproperty(C, f)
+                end
+
+                # Update `U`.
+                C_new = ConstructionBase.setproperties(C, (U=parent(C.U),))
+                for f in propertynames(C)
+                    @test getproperty(C_new, f) == getproperty(C, f)
+                end
+
+                # Update `UL`
+                C_new = ConstructionBase.setproperties(C, (UL=parent(C.UL),))
+                for f in propertynames(C)
+                    @test getproperty(C_new, f) == getproperty(C, f)
+                end
+
+                # Invalid patches.
+                @test_throws ErrorException ConstructionBase.setproperties(C, (L=parent(C.L), U=parent(C.U),))
+                @test_throws ErrorException ConstructionBase.setproperties(C, (UL=parent(C.UL), U=parent(C.U),))
+                @test_throws ErrorException ConstructionBase.setproperties(C, (UL=parent(C.UL), L=parent(C.L),))
+            end
+        end
+    end
+
     @testset "Expr" begin
         e = :(a + b)
         @test e == @inferred constructorof(typeof(e))(getfields(e)...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -227,10 +227,10 @@ end
                 end
 
                 # Invalid patches.
-                @test_throws "Can only patch one of" ConstructionBase.setproperties(C, (L=parent(C.L), U=parent(C.U),))
-                @test_throws "Can only patch one of" ConstructionBase.setproperties(C, (UL=parent(C.UL), U=parent(C.U),))
-                @test_throws "Can only patch one of" ConstructionBase.setproperties(C, (UL=parent(C.UL), L=parent(C.L),))
-                @test_throws "Invalid patch" ConstructionBase.setproperties(C, (asdf=parent(C.UL),))
+                @test_throws ArgumentError ConstructionBase.setproperties(C, (L=parent(C.L), U=parent(C.U),))
+                @test_throws ArgumentError ConstructionBase.setproperties(C, (UL=parent(C.UL), U=parent(C.U),))
+                @test_throws ArgumentError ConstructionBase.setproperties(C, (UL=parent(C.UL), L=parent(C.L),))
+                @test_throws ArgumentError ConstructionBase.setproperties(C, (asdf=parent(C.UL),))
             end
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -200,41 +200,43 @@ end
         @testset "uplo=$uplo" for uplo in ['L', 'U']
             C = Cholesky(X, uplo, 0)
 
-            @testset "only setting value" begin
-                # Empty patch.
-                C_new = ConstructionBase.setproperties(C, NamedTuple())
-                @test typeof(C_new) === typeof(C)
-                for f in propertynames(C)
-                    @test getproperty(C_new, f) == getproperty(C, f)
-                end
-
-                # Update `L`.
-                C_new = ConstructionBase.setproperties(C, (L=2 .* parent(C.L),))
-                @test typeof(C_new) === typeof(C)
-                for f in propertynames(C)
-                    @test getproperty(C_new, f) == 2 .* getproperty(C, f)
-                end
-
-                # Update `U`.
-                C_new = ConstructionBase.setproperties(C, (U=2 .* parent(C.U),))
-                @test typeof(C_new) === typeof(C)
-                for f in propertynames(C)
-                    @test getproperty(C_new, f) == 2 .* getproperty(C, f)
-                end
-
-                # Update `UL`
-                C_new = ConstructionBase.setproperties(C, (UL=2 .* parent(C.UL),))
-                @test typeof(C_new) === typeof(C)
-                for f in propertynames(C)
-                    @test getproperty(C_new, f) == 2 .* getproperty(C, f)
-                end
-
-                # Invalid patches.
-                @test_throws ArgumentError ConstructionBase.setproperties(C, (L=parent(C.L), U=parent(C.U),))
-                @test_throws ArgumentError ConstructionBase.setproperties(C, (UL=parent(C.UL), U=parent(C.U),))
-                @test_throws ArgumentError ConstructionBase.setproperties(C, (UL=parent(C.UL), L=parent(C.L),))
-                @test_throws ArgumentError ConstructionBase.setproperties(C, (asdf=parent(C.UL),))
+            # Empty patch.
+            C_new = ConstructionBase.setproperties(C, NamedTuple())
+            @test typeof(C_new) === typeof(C)
+            for f in propertynames(C)
+                @test getproperty(C_new, f) == getproperty(C, f)
             end
+
+            # Update `L`.
+            C_new = ConstructionBase.setproperties(C, (L=2 .* C.L,))
+            @test typeof(C_new) === typeof(C)
+            for f in propertynames(C)
+                @test getproperty(C_new, f) == 2 .* getproperty(C, f)
+            end
+
+            # Update `U`.
+            C_new = ConstructionBase.setproperties(C, (U=2 .* C.U,))
+            @test typeof(C_new) === typeof(C)
+            for f in propertynames(C)
+                @test getproperty(C_new, f) == 2 .* getproperty(C, f)
+            end
+
+            # Update `UL`
+            C_new = ConstructionBase.setproperties(C, (UL=2 .* C.UL,))
+            @test typeof(C_new) === typeof(C)
+            for f in propertynames(C)
+                @test getproperty(C_new, f) == 2 .* getproperty(C, f)
+            end
+
+            # We can only set the properties with `LowerTriangular` or `UpperTriangular` matrices.
+            @test_throws ArgumentError ConstructionBase.setproperties(C, (L=parent(C.L),))
+            @test_throws ArgumentError ConstructionBase.setproperties(C, (U=parent(C.U),))
+            # Can only set one at the time.
+            @test_throws ArgumentError ConstructionBase.setproperties(C, (L=C.L, U=C.U,))
+            @test_throws ArgumentError ConstructionBase.setproperties(C, (UL=C.UL, U=C.U,))
+            @test_throws ArgumentError ConstructionBase.setproperties(C, (UL=C.UL, L=C.L,))
+            # And make sure any other patch will fail.
+            @test_throws ArgumentError ConstructionBase.setproperties(C, (asdf=C.UL,))
         end
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -227,9 +227,10 @@ end
                 end
 
                 # Invalid patches.
-                @test_throws ErrorException ConstructionBase.setproperties(C, (L=parent(C.L), U=parent(C.U),))
-                @test_throws ErrorException ConstructionBase.setproperties(C, (UL=parent(C.UL), U=parent(C.U),))
-                @test_throws ErrorException ConstructionBase.setproperties(C, (UL=parent(C.UL), L=parent(C.L),))
+                @test_throws "Can only patch one of" ConstructionBase.setproperties(C, (L=parent(C.L), U=parent(C.U),))
+                @test_throws "Can only patch one of" ConstructionBase.setproperties(C, (UL=parent(C.UL), U=parent(C.U),))
+                @test_throws "Can only patch one of" ConstructionBase.setproperties(C, (UL=parent(C.UL), L=parent(C.L),))
+                @test_throws "Invalid patch" ConstructionBase.setproperties(C, (asdf=parent(C.UL),))
             end
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -195,7 +195,6 @@ end
     end
 
     @testset "Cholesky" begin
-        # X = Matrix(Diagonal(ones(3)))
         x = randn(3, 3)
         X = x * x'
         @testset "uplo=$uplo" for uplo in ['L', 'U']

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -208,24 +208,24 @@ end
             end
 
             # Update `L`.
-            C_new = ConstructionBase.setproperties(C, (L=2 .* C.L,))
+            C_new = ConstructionBase.setproperties(C, (L=2 * C.L,))
             @test typeof(C_new) === typeof(C)
             for f in propertynames(C)
-                @test getproperty(C_new, f) == 2 .* getproperty(C, f)
+                @test getproperty(C_new, f) == 2 * getproperty(C, f)
             end
 
             # Update `U`.
-            C_new = ConstructionBase.setproperties(C, (U=2 .* C.U,))
+            C_new = ConstructionBase.setproperties(C, (U=2 * C.U,))
             @test typeof(C_new) === typeof(C)
             for f in propertynames(C)
-                @test getproperty(C_new, f) == 2 .* getproperty(C, f)
+                @test getproperty(C_new, f) == 2 * getproperty(C, f)
             end
 
             # Update `UL`
-            C_new = ConstructionBase.setproperties(C, (UL=2 .* C.UL,))
+            C_new = ConstructionBase.setproperties(C, (UL=2 * C.UL,))
             @test typeof(C_new) === typeof(C)
             for f in propertynames(C)
-                @test getproperty(C_new, f) == 2 .* getproperty(C, f)
+                @test getproperty(C_new, f) == 2 * getproperty(C, f)
             end
 
             # We can only set the properties with `LowerTriangular` or `UpperTriangular` matrices.


### PR DESCRIPTION
`propertynames` is overloaded for `LinearAlgebra.Cholesky`, hence it requires impl of `setproperties`. I've made an attempt at that in this PR:)