### PR TITLE
Use strict equality for comparing properties

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ConstructionBase"
 uuid = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
 authors = ["Takafumi Arakaki", "Rafael Schouten", "Jan Weidner"]
-version = "1.5.4"
+version = "1.5.5"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/ConstructionBase.jl
+++ b/src/ConstructionBase.jl
@@ -50,7 +50,7 @@ getproperties(o::Tuple) = o
 
 if VERSION >= v"1.7"
     function check_properties_are_fields(obj)
-        if propertynames(obj) != fieldnames(typeof(obj))
+        if propertynames(obj) !== fieldnames(typeof(obj))
             error("""
             The function `Base.propertynames` was overloaded for type `$(typeof(obj))`.
             Please make sure `ConstructionBase.setproperties` is also overloaded for this type.

--- a/src/ConstructionBase.jl
+++ b/src/ConstructionBase.jl
@@ -50,7 +50,8 @@ getproperties(o::Tuple) = o
 
 if VERSION >= v"1.7"
     function check_properties_are_fields(obj)
-        # triple equals makes it easier for the compiler to optimize, see #82
+        # for ntuples of symbols `===` is semantically the same as `==`
+        # but triple equals is easier for the compiler to optimize, see #82
         if propertynames(obj) !== fieldnames(typeof(obj))
             error("""
             The function `Base.propertynames` was overloaded for type `$(typeof(obj))`.

--- a/src/ConstructionBase.jl
+++ b/src/ConstructionBase.jl
@@ -50,6 +50,7 @@ getproperties(o::Tuple) = o
 
 if VERSION >= v"1.7"
     function check_properties_are_fields(obj)
+        # triple equals makes it easier for the compiler to optimize, see #82
         if propertynames(obj) !== fieldnames(typeof(obj))
             error("""
             The function `Base.propertynames` was overloaded for type `$(typeof(obj))`.


### PR DESCRIPTION
We found that for really large tuples the Julia compiler would give up on constfolding the comparison leading to a runtime check. Tuples of symbols are `===` so this change makes it easier for the compiler to inline.