### PR TITLE
only test that `getfields` on an array produce no fields if it actually has no fields

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,7 +21,9 @@ end
 
 @testset "getfields" begin
     @test getfields(()) === ()
-    @test getfields([]) === NamedTuple()
+    if isempty(fieldnames(Vector{Any}))
+        @test getfields([]) === NamedTuple()
+    end
     @test getfields(Empty()) === NamedTuple()
     @test getfields(NamedTuple()) === NamedTuple()
     @test getfields((10,20,30)) === (10,20,30)
@@ -425,7 +427,7 @@ function write_output_to_ref!(f, out_ref::Ref, arg_ref1::Ref, arg_ref2::Ref)
     out_ref
 end
 function hot_loop_allocs(f::F, args...) where {F}
-    # we want to test that f(args...) does not allocate 
+    # we want to test that f(args...) does not allocate
     # when used in hot loops
     # however a naive @allocated f(args...)
     # will not be representative of what happens in an inner loop
@@ -562,7 +564,7 @@ if isdefined(Base, :get_extension)  # some 1.9 version
         @test all(ma2 .=== @MMatrix [1 3; 2 4])
 
         sz = SizedArray{Tuple{2,2}}([1 2;3 4])
-        sz2 = @inferred ConstructionBase.constructorof(typeof(sz))([:a :b; :c :d]) 
+        sz2 = @inferred ConstructionBase.constructorof(typeof(sz))([:a :b; :c :d])
         @test sz2 == SizedArray{Tuple{2,2}}([:a :b; :c :d])
         @test typeof(sz2) <: SizedArray{Tuple{2,2},Symbol,2,2}
 


### PR DESCRIPTION
On julia 1.11+, an array actually has an inner structure (`Memory`)