### PR TITLE
add LinearAlgebraExt

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,20 +9,24 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 [weakdeps]
 IntervalSets = "8197267c-284f-5f27-9208-e0e47529a953"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [extensions]
 ConstructionBaseIntervalSetsExt = "IntervalSets"
 ConstructionBaseStaticArraysExt = "StaticArrays"
+ConstructionBaseLinearAlgebraExt = "LinearAlgebra"
 
 [compat]
 IntervalSets = "0.5, 0.6, 0.7"
 StaticArrays = "1"
 julia = "1"
+LinearAlgebra = "1"
 
 [extras]
 IntervalSets = "8197267c-284f-5f27-9208-e0e47529a953"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [targets]
-test = ["IntervalSets","StaticArrays","Test"]
+test = ["IntervalSets","LinearAlgebra","StaticArrays","Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -20,7 +20,7 @@ ConstructionBaseLinearAlgebraExt = "LinearAlgebra"
 IntervalSets = "0.5, 0.6, 0.7"
 StaticArrays = "1"
 julia = "1"
-LinearAlgebra = "1"
+LinearAlgebra = "<0.0.1,1"
 
 [extras]
 IntervalSets = "8197267c-284f-5f27-9208-e0e47529a953"

--- a/Project.toml
+++ b/Project.toml
@@ -9,12 +9,10 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 [weakdeps]
 IntervalSets = "8197267c-284f-5f27-9208-e0e47529a953"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
-LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [extensions]
 ConstructionBaseIntervalSetsExt = "IntervalSets"
 ConstructionBaseStaticArraysExt = "StaticArrays"
-ConstructionBaseLinearAlgebraExt = "LinearAlgebra"
 
 [compat]
 IntervalSets = "0.5, 0.6, 0.7"

--- a/ext/ConstructionBaseLinearAlgebraExt.jl
+++ b/ext/ConstructionBaseLinearAlgebraExt.jl
@@ -1,12 +1,7 @@
 module ConstructionBaseLinearAlgebraExt
 
-if isdefined(Base, :get_extension)
-    import ConstructionBase
-    import LinearAlgebra
-else
-    import ..ConstructionBase
-    import ..LinearAlgebra
-end
+import ConstructionBase
+import LinearAlgebra
 
 ### Tridiagonal
 

--- a/ext/ConstructionBaseLinearAlgebraExt.jl
+++ b/ext/ConstructionBaseLinearAlgebraExt.jl
@@ -1,0 +1,51 @@
+module ConstructionBaseLinearAlgebraExt
+
+if !isdefined(Base, :get_extension)
+    import ConstructionBase
+    import LinearAlgebra
+else
+    import ..ConstructionBase
+    import ..LinearAlgebra
+end
+
+### Tridiagonal
+
+function tridiagonal_constructor(dl::V, d::V, du::V) where {V<:AbstractVector{T}} where T
+    LinearAlgebra.Tridiagonal{T,V}(dl, d, du)
+end
+function tridiagonal_constructor(dl::V, d::V, du::V, du2::V) where {V<:AbstractVector{T}} where T
+    LinearAlgebra.Tridiagonal{T,V}(dl, d, du, du2)
+end
+
+# `du2` may be undefined, so we need a custom `getfields` that checks `isdefined`
+function ConstructionBase.getfields(o::LinearAlgebra.Tridiagonal)
+    if isdefined(o, :du2)
+        (dl=o.dl, d=o.d, du=o.du, du2=o.du2)
+    else
+        (dl=o.dl, d=o.d, du=o.du)
+    end
+end
+
+ConstructionBase.constructorof(::Type{<:LinearAlgebra.Tridiagonal}) = tridiagonal_constructor
+
+### Cholesky
+
+ConstructionBase.setproperties(C::LinearAlgebra.Cholesky, patch::NamedTuple{()}) = C
+
+function ConstructionBase.setproperties(C::LinearAlgebra.Cholesky, patch::NamedTuple{(:L,),<:Tuple{<:LinearAlgebra.LowerTriangular}})
+    return LinearAlgebra.Cholesky(C.uplo === 'U' ? copy(patch.L.data') : patch.L.data, C.uplo, C.info)
+end
+function ConstructionBase.setproperties(C::LinearAlgebra.Cholesky, patch::NamedTuple{(:U,),<:Tuple{<:LinearAlgebra.UpperTriangular}})
+    return LinearAlgebra.Cholesky(C.uplo === 'L' ? copy(patch.U.data') : patch.U.data, C.uplo, C.info)
+end
+function ConstructionBase.setproperties(
+    C::LinearAlgebra.Cholesky,
+    patch::NamedTuple{(:UL,),<:Tuple{<:Union{LinearAlgebra.LowerTriangular,LinearAlgebra.UpperTriangular}}}
+)
+    return LinearAlgebra.Cholesky(patch.UL.data, C.uplo, C.info)
+end
+function ConstructionBase.setproperties(C::LinearAlgebra.Cholesky, patch::NamedTuple)
+    throw(ArgumentError("Invalid patch for `Cholesky`: $(patch)"))
+end
+
+end #module

--- a/ext/ConstructionBaseLinearAlgebraExt.jl
+++ b/ext/ConstructionBaseLinearAlgebraExt.jl
@@ -1,6 +1,6 @@
 module ConstructionBaseLinearAlgebraExt
 
-if !isdefined(Base, :get_extension)
+if isdefined(Base, :get_extension)
     import ConstructionBase
     import LinearAlgebra
 else

--- a/src/ConstructionBase.jl
+++ b/src/ConstructionBase.jl
@@ -222,4 +222,7 @@ end
 include("nonstandard.jl")
 include("functions.jl")
 
+#unconditionally include the extension for now
+include("../ext/ConstructionBaseLinearAlgebraExt.jl")
+
 end # module

--- a/src/nonstandard.jl
+++ b/src/nonstandard.jl
@@ -1,4 +1,3 @@
-using LinearAlgebra
 
 ### SubArray
 # `offset1` and `stride1` fields are calculated from parent indices.
@@ -41,5 +40,6 @@ constructorof(::Type{<:LinRange}) = linrange_constructor
 constructorof(::Type{<:Expr}) = (head, args) -> Expr(head, args...)::Expr
 
 if !isdefined(Base,:get_extension)
+    using LinearAlgebra
     include("ext/ConstructionBaseLinearAlgebraExt.jl")
 end

--- a/src/nonstandard.jl
+++ b/src/nonstandard.jl
@@ -38,8 +38,3 @@ constructorof(::Type{<:LinRange}) = linrange_constructor
 ### Expr: args get splatted
 # ::Expr annotation is to make it type-stable on Julia 1.3-
 constructorof(::Type{<:Expr}) = (head, args) -> Expr(head, args...)::Expr
-
-if !isdefined(Base,:get_extension)
-    using LinearAlgebra
-    include("../ext/ConstructionBaseLinearAlgebraExt.jl")
-end

--- a/src/nonstandard.jl
+++ b/src/nonstandard.jl
@@ -41,5 +41,5 @@ constructorof(::Type{<:Expr}) = (head, args) -> Expr(head, args...)::Expr
 
 if !isdefined(Base,:get_extension)
     using LinearAlgebra
-    include("..ext/ConstructionBaseLinearAlgebraExt.jl")
+    include("../ext/ConstructionBaseLinearAlgebraExt.jl")
 end

--- a/src/nonstandard.jl
+++ b/src/nonstandard.jl
@@ -41,5 +41,5 @@ constructorof(::Type{<:Expr}) = (head, args) -> Expr(head, args...)::Expr
 
 if !isdefined(Base,:get_extension)
     using LinearAlgebra
-    include("ext/ConstructionBaseLinearAlgebraExt.jl")
+    include("..ext/ConstructionBaseLinearAlgebraExt.jl")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,7 +29,7 @@ end
         @test getfields([]) === NamedTuple()
     else
         arr = []
-        @test getfields(arr) === (;arr.ref, arr.size)
+        @test getfields(arr) === (ref = arr.ref, size = arr.size)
     end
     @test getfields(Empty()) === NamedTuple()
     @test getfields(NamedTuple()) === NamedTuple()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,7 +28,8 @@ end
     if !isdefined(Base,:Memory)
         @test getfields([]) === NamedTuple()
     else
-        @test getfields([]).size === (0,)
+        arr = []
+        @test getfields(arr) === (;arr.ref, arr.size)
     end
     @test getfields(Empty()) === NamedTuple()
     @test getfields(NamedTuple()) === NamedTuple()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,7 +21,15 @@ end
 
 @testset "getfields" begin
     @test getfields(()) === ()
-    @test getfields([]) === NamedTuple()
+
+    #on julia 1.10 onwards, Array has fields :ref and :size. the :ref field is a memory field
+    #with non-constant value (the pointer location in memory). The only constant field in []
+    #is it's size, (0,)
+    if !isdefined(Base,:Memory)
+        @test getfields([]) === NamedTuple()
+    else
+        @test getfields([]).size === (0,)
+    end
     @test getfields(Empty()) === NamedTuple()
     @test getfields(NamedTuple()) === NamedTuple()
     @test getfields((10,20,30)) === (10,20,30)


### PR DESCRIPTION
should make the package dependency free on julia > 1.9. motivated by [JuliaFolds2/Trand](https://github.com/JuliaFolds2/Transducers.jl/issues/35)