### PR TITLE
Improve performance of `setproperties`/`getproperties` for structs with unions

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -476,6 +476,17 @@ end
     end
 end
 
+struct S2
+    a::Union{Nothing, Int}
+    b::Union{UInt32, Int32}
+end
+
+@testset "no allocs S2" begin
+    obj = S2(3, UInt32(5))
+    @test 0 == hot_loop_allocs(constructorof, typeof(obj))
+    @test 0 == hot_loop_allocs(setproperties, obj, (; a = nothing, b = Int32(6)))
+end
+
 @testset "inference" begin
     @testset "Tuple n=$n" for n in [0,1,2,3,4,5,10,20,30,40]
         t = funny_numbers(Tuple,n)


### PR DESCRIPTION
Addresses #55.

These changes make use of generated functions in the case where properties are fields, both for `getproperties` and `setproperties`.

In terms of performance, see
```julia-repl
julia> using ConstructionBase

julia> using BenchmarkTools

julia> struct A
           a::String
       end

julia> x = A("hello");

julia> @btime getproperties($x)
  1.259 ns (0 allocations: 0 bytes)
(a = "hello",)

julia> @btime setproperties($x, (; a = $("world")))
  1.433 ns (0 allocations: 0 bytes)
A("world")

julia> struct B
           a::Union{Nothing, String}
       end

julia> x = B("hello");

julia> @btime getproperties($x)
  53.251 ns (2 allocations: 32 bytes)
(a = "hello",)

julia> @btime setproperties($x, (; a = nothing))
  0.759 ns (0 allocations: 0 bytes)
B(nothing)

julia> @btime B(nothing)
  0.719 ns (0 allocations: 0 bytes)
B(nothing)
```

`getproperties` still allocates, this is due to using a `NamedTuple` that contains a union for one of its fields. I guess one could force the `Union` to be formed on the outside, e.g. `Union{NamedTuple{....}, NamedTuple{...}}`, but I think the current state is fine and has the benefit of simplicity. `setproperties` is as fast as one would expect, at least.

The `"no allocs S2"` testset captures the performance improvements of this PR, failing on current `master`.