### PR TITLE
improve setproperties() error message

### DIFF
--- a/src/ConstructionBase.jl
+++ b/src/ConstructionBase.jl
@@ -55,7 +55,7 @@ if VERSION >= v"1.7"
         if propertynames(obj) !== fieldnames(typeof(obj))
             error("""
             The `$(nameof(typeof(obj)))` type defines custom properties: it has `propertynames` overloaded.
-            Please define `ConstructionBase.setproperties(::`$(nameof(typeof(obj)))`, ::NamedTuple)` to set its properties.
+            Please define `ConstructionBase.setproperties(::$(nameof(typeof(obj))), ::NamedTuple)` to set its properties.
             """)
         end
     end


### PR DESCRIPTION
Currently, it can be both too long and unclear for novices (I saw some confusion), eg:

>ERROR: The function `Base.propertynames` was overloaded for type `Mesh{3, Float32, GeometryBasics.Ngon{3, Float32, 3, Point{3, Float32}}, SimpleFaceView{3, Float32, 3, OffsetInteger{-1, UInt32}, Point{3, Float32}, NgonFace{3, OffsetInteger{-1, UInt32}}}}`.
> Please make sure `ConstructionBase.setproperties` is also overloaded for this type.

This PR changes it to:

> The `Mesh` type defines custom properties: it has `propertynames` overloaded.
> Please define `ConstructionBase.setproperties(::Mesh, ::NamedTuple)` to set its properties.

Happy to rephrase if you have other suggestions!