### PR TITLE
Make LinearAlgebra a weak dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,17 +1,19 @@
 name = "ConstructionBase"
 uuid = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
 authors = ["Takafumi Arakaki", "Rafael Schouten", "Jan Weidner"]
-version = "1.5.7"
+version = "1.5.8"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [weakdeps]
 IntervalSets = "8197267c-284f-5f27-9208-e0e47529a953"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [extensions]
 ConstructionBaseIntervalSetsExt = "IntervalSets"
+ConstructionBaseLinearAlgebraExt = "LinearAlgebra"
 ConstructionBaseStaticArraysExt = "StaticArrays"
 
 [compat]

--- a/src/ConstructionBase.jl
+++ b/src/ConstructionBase.jl
@@ -211,7 +211,8 @@ end
 include("nonstandard.jl")
 include("functions.jl")
 
-#unconditionally include the extension for now
-include("../ext/ConstructionBaseLinearAlgebraExt.jl")
+if !isdefined(Base, :get_extension)
+    include("../ext/ConstructionBaseLinearAlgebraExt.jl")
+end
 
 end # module


### PR DESCRIPTION
ConstructionBase doesn't depend on anything (apart from LinearAlgebra currently), so it can't trigger the circular dependency issue. It's completely safe to make LinearAlgebra a weak dependency on all Julia versions that support weak dependencies.

On the contrary, if ConstructionBase keeps LinearAlgebra as a direct dependency, then packages that depend on ConstructionBase and decide to make LinearAlgebra a weak dependency (e.g. Accessors) will run into the circular dependency issue. So a direct dependency on LinearAlgebra in ConstructionBase holds back large parts of the ecosystem.