### PR TITLE
make the `constructorof` fallback method non-`@generated`

### DIFF
--- a/src/ConstructionBase.jl
+++ b/src/ConstructionBase.jl
@@ -26,7 +26,7 @@ for (name, path) in [
     end
 end
 
-@generated function constructorof(::Type{T}) where T
+function constructorof(::Type{T}) where T
     getfield(parentmodule(T), nameof(T))
 end
 


### PR DESCRIPTION
I don't see a justification for using `@generated`. The effects are good without it:

```julia-repl
julia> Base.infer_effects(constructorof, Tuple{Type{Int}})
(+c,+e,+n,+t,+s,+m,+u,+o,+r)
```

Updates #21