### PR TITLE
rebase PR #100: "fix for FunctionConstructor UB"

### DIFF
--- a/src/functions.jl
+++ b/src/functions.jl
@@ -19,6 +19,6 @@ _isgensym(s::Symbol) = occursin("#", string(s))
 end
 
 function ConstructionBase.constructorof(f::Type{F}) where F <: Function
-    FunctionConstructor{F}()
+    FunctionConstructor{typename(F).wrapper}()
 end
 

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -19,6 +19,6 @@ _isgensym(s::Symbol) = occursin("#", string(s))
 end
 
 function ConstructionBase.constructorof(f::Type{F}) where F <: Function
-    FunctionConstructor{typename(F).wrapper}()
+    FunctionConstructor{Base.typename(F).wrapper}()
 end
 

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -8,11 +8,10 @@ _isgensym(s::Symbol) = occursin("#", string(s))
 @generated function (fc::FunctionConstructor{F})(args...) where F
     isempty(args) && return Expr(:new, F)
 
-    T = getfield(parentmodule(F), nameof(F))
     # We assume all gensym names are anonymous functions
-    _isgensym(nameof(F)) || return :($T(args...))
+    _isgensym(nameof(F)) || return :($F(args...))
     # Define `new` for rebuilt function type that matches args
-    exp = Expr(:new, Expr(:curly, T, args...))
+    exp = Expr(:new, Expr(:curly, F, args...))
     for i in 1:length(args)
         push!(exp.args, :(args[$i]))
     end


### PR DESCRIPTION
This should finally make ConstructionBase usable on v1.12 and v1.13. Makes the test suite pass, without this PR it errors with `UndefVarError`.

xref #100