### PR TITLE
`check_patch_field_exist`: remove SnoopCompile noise by explicitly specifying `Base.nothing`

### DIFF
--- a/src/ConstructionBase.jl
+++ b/src/ConstructionBase.jl
@@ -97,7 +97,7 @@ setproperties(obj::Tuple      , patch::NamedTuple ) = setproperties_tuple(obj   
 @generated function check_patch_fields_exist(obj, patch)
     fnames = fieldnames(obj)
     pnames = fieldnames(patch)
-    pnames ⊆ fnames ? :(nothing) : :(throw(ArgumentError($("Failed to assign fields $pnames to object with fields $fnames."))))
+    pnames ⊆ fnames ? :(Base.nothing) : :(throw(ArgumentError($("Failed to assign fields $pnames to object with fields $fnames."))))
 end
 
 function setproperties(obj::NamedTuple{fields}, patch::NamedTuple{fields}) where {fields}


### PR DESCRIPTION
I think this is a julia issue but without this change I get a bunch of noise with SnoopCompile of the form

```
, rebinding Core.Binding(:(ConstructionBase.nothing), #undef, #undef, #undef, 0x08) invalidated:
   mt_backedges:  1: signature ConstructionBase.nothing triggered MethodInstance for ConstructionBase.check_patch_fields_exist(::NonlinearProblem{Vector{Float64}, true, Float64, NonlinearFunction{true, SciMLBase.NoSpecialize, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Nothing, Any, Any, Any}, Base.Pairs{Symbol, Union{}, Nothing, @NamedTuple{}}, SciMLBase.StandardNonlinearProblem, Nothing, Nothing}, ::@NamedTuple{p::Float64}) (0 children)
                  2: signature ConstructionBase.nothing triggered MethodInstance for ConstructionBase.check_patch_fields_exist(::NonlinearProblem{Vector{Float64}, true, Float64, NonlinearFunction{true, SciMLBase.NoSpecialize, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Nothing, Any, Any, Any}, Base.Pairs{Symbol, Union{}, Nothing, @NamedTuple{}}, SciMLBase.StandardNonlinearProblem, Nothing, Nothing}, ::@NamedTuple{u0::Vector{Float64}}) (0 children)
                  3: signature ConstructionBase.nothing triggered MethodInstance for ConstructionBase.check_patch_fields_exist(::NonlinearProblem{Vector{Float64}, false, Float64, NonlinearFunction{false, SciMLBase.NoSpecialize, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Nothing, Any, Any, Any}, Base.Pairs{Symbol, Union{}, Nothing, @NamedTuple{}}, SciMLBase.StandardNonlinearProblem, Nothing, Nothing}, ::@NamedTuple{p::Float64}) (0 children)
 ...
```

for many many lines. It isn't clear to me if this is a problem in practice but it shouldn't be harmful and it reduces the noise for someone who happens to run SnoopCompile with a package that depends on ConstructionBase.jl